### PR TITLE
Localization and Modularization of TS Plugin 

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -17,14 +17,35 @@
         "type": "string",
         "required": true
       },
+      "language": {
+        "title": "Services Language",
+        "description": "The displayed language of the registered services (and associated Siri commands)",
+        "type": "string",
+        "default": "en",
+        "oneOf": [
+          {
+            "title": "English",
+            "enum": ["en"]
+          },
+          {
+            "title": "German",
+            "enum": ["de"]
+          },
+          {
+            "title": "French",
+            "enum": ["fr"]
+          }
+        ],
+        "required": true
+      },
       "prefix": {
-        "title": "Prefix robot name",
+        "title": "Prefix with Robot Name",
         "description": "Display the name of the robot in front of every service.",
         "type": "boolean",
         "default": false
       },
       "backgroundUpdate": {
-        "title": "Background update",
+        "title": "Background Update Interval",
         "description": "Interval for background updates while the robot is not cleaning (in minutes). During cleaning, the robot will automatically update at a faster rate.",
         "type": "integer",
         "minimum": 1,
@@ -32,32 +53,53 @@
       },
       "services": {
         "type": "array",
+        "title": "Displayed Services",
+        "description": "The services to be made available for Homekit",
+        "uniqueItems": true,
         "items": {
           "type": "string",
           "enum": [
-            "Clean house",
-            "Clean spot",
-            "Go to dock",
-            "Find me",
+            "clean",
+            "cleanZone",
+            "cleanSpot",
+            "goToDock",
+            "dockState",
+            "binFull",
+            "eco",
+            "noGoLines",
+            "extraCare",
+            "schedule",
+            "findMe",
+            "battery"
+          ],
+          "enumNames": [
+            "Clean",
+            "Clean Zone",
+            "Clean Spot",
+            "Go to Dock",
+            "Docked State",
+            "Bin Full",
+            "Eco Mode",
+            "NoGo Lines",
+            "Extra Care",
             "Schedule",
-            "Eco",
-            "Nogo lines",
-            "Extra care",
-            "Docked sensor",
-            "Bin full sensor"
+            "Find me",
+            "Battery"
           ]
         },
         "default": [
-          "Clean house",
-          "Clean spot",
-          "Go to dock",
-          "Find me",
-          "Schedule",
-          "Eco",
-          "Nogo lines",
-          "Extra care",
-          "Docked sensor",
-          "Bin full sensor"
+          "clean",
+          "cleanZone",
+          "goToDock",
+          "dockState",
+          "binFull",
+          "eco",
+          "noGoLines",
+          "extraCare",
+          "schedule",
+          "findMe",
+          "cleanSpot",
+          "battery"
         ]
       }
     }
@@ -88,9 +130,11 @@
     },
     "backgroundUpdate",
     "prefix",
+    "language",
+
     {
       "type": "fieldset",
-      "title": "Services",
+      "title": "Displayed Services",
       "description": "<i>Services to be displayed in Homekit</i>",
       "expandable": true,
       "items": [

--- a/src/characteristics/characteristicHandler.ts
+++ b/src/characteristics/characteristicHandler.ts
@@ -1,0 +1,7 @@
+import { Characteristic, CharacteristicGetHandler, CharacteristicSetHandler, WithUUID } from "homebridge";
+
+export declare interface CharacteristicHandler{
+    characteristic: WithUUID<new () => Characteristic>
+    getCharacteristicHandler?: CharacteristicGetHandler, 
+    setCharacteristicHandler?: CharacteristicSetHandler
+}

--- a/src/defaults.ts
+++ b/src/defaults.ts
@@ -1,0 +1,6 @@
+import { RobotService } from "./models/services";
+
+export const BACKGROUND_INTERVAL = 30;
+export const PREFIX = false;
+export const ALL_SERVICES = new Set(Object.values(RobotService));
+export const LOCALE = "en"

--- a/src/localization.ts
+++ b/src/localization.ts
@@ -1,0 +1,57 @@
+export enum availableLocales {
+    EN = "en",
+    DE = "de",
+    FR = "fr",
+}
+
+const localizationDicts = {
+    'en': {
+        "clean": "Clean",
+        "cleanZone": "Clean Zone",
+        "cleanThe": "Clean the",
+        "goToDock": "Go to Dock",
+        "dockState": "Docked",
+        "binFull": "Bin Full",
+        "eco": "Eco Mode",
+        "noGoLines": "NoGo Lines",
+        "extraCare": "Extra Care",
+        "schedule": "Schedule",
+        "findMe": "Find me",
+        "cleanSpot": "Clean Spot",
+        "battery": "Battery"
+    },
+    'de': {
+        "clean": "Sauge",
+        "cleanZone": "Sauge Zone",
+        "cleanThe": "Sauge",
+        "goToDock": "Zur Basis",
+        "dockState": "In der Basis",
+        "binFull": "Behälter voll",
+        "eco": "Eco Modus",
+        "noGoLines": "NoGo Linien",
+        "extraCare": "Extra Care",
+        "schedule": "Zeitplan",
+        "findMe": "Finde mich",
+        "cleanSpot": "Spot Reinigung",
+        "battery": "Batterie"
+    },
+    'fr': {
+        "clean": "Aspirer",
+        "cleanZone": "Aspirer Zone",
+        "cleanThe": "Aspirer",
+        "goToDock": "Retour à la base",
+        "dockState": "Sur la base",
+        "binFull": "Conteneur plein",
+        "eco": "Eco mode",
+        "noGoLines": "Lignes NoGo",
+        "extraCare": "Extra Care",
+        "schedule": "Planifier",
+        "findMe": "Me retrouver",
+        "cleanSpot": "Nettoyage local",
+        "battery": "Batterie"
+    }
+}
+
+export function localize(label: string, locale: availableLocales) : string {
+    return localizationDicts[locale][label] ?? label
+}

--- a/src/models/services.ts
+++ b/src/models/services.ts
@@ -1,0 +1,19 @@
+export enum CleanType {
+  ALL,
+  SPOT,
+}
+
+export enum RobotService {
+  CLEAN = "clean",
+  CLEAN_SPOT = "cleanSpot",
+  CLEAN_ZONE = "cleanZone",
+  GO_TO_DOCK = "goToDock",
+  DOCKED = "dockState",
+  BIN_FULL = "binFull",
+  FIND_ME = "findMe",
+  SCHEDULE = "schedule",
+  ECO = "eco",
+  NOGO_LINES = "noGoLines",
+  EXTRA_CARE = "extraCare",
+  BATTERY = "battery",
+}


### PR DESCRIPTION
Add localization as in #65, but for the TS variant of the plugin:
- Adds Language selection (also via homebridge UI) for English, German, French. 
- Solves #59 . 

In this context, I have restructured the plugin a bit to be a bit more modular. 
Note that I have unified `getSwitchService` and `getOccupancyService` into one `registerService` function with an optional list of added characteristic handlers as an argument. 
Getting the `Services` is now done via `this.accessory.getServiceById(serviceType, serviceName)` instead of `this.accessory.getService(displayName)` to not rely on the display name for service identification.